### PR TITLE
bump google-github-actions/auth, remove redundant auth

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,18 +19,10 @@ runs:
         echo "GCP_SERVICE_ACCOUNT=$(echo -n ${{ inputs.base64_gcp_service_account}} | base64 -d)" >> $GITHUB_ENV
     - name: Workload Identity Auth
       id: auth
-      uses: google-github-actions/auth@v0.7.1
+      uses: google-github-actions/auth@v0.8.0
       with:
         workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
-    - name: Debug gcloud auth
-      shell: bash
-      run: gcloud auth list
-    - name: Gcloud auth
-      shell: bash
-      run: |-
-        gcloud auth login --brief --cred-file="${{ steps.auth.outputs.credentials_file_path }}"
-      #"
     - name: Debug gcloud auth
       shell: bash
       run: gcloud auth list


### PR DESCRIPTION
this should get rid of the warnings about overriding environment variables, but let's keep an eye out for workflows breaking