### PR TITLE
remove only_auth param

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,10 @@ inputs:
   gcp_service_account:
     description: GCP service Account
     required: true
-  only_auth:
-    description: Set to true to skip setting up gcloud SDK and just do workload ID auth
-    required: false
-    default: "false"
+  #only_auth:
+  #  description: Set to true to skip setting up gcloud SDK and just do workload ID auth
+  #  required: false
+  #  default: "false"
 outputs:
   project_id:
     description: |-
@@ -49,7 +49,7 @@ runs:
         echo access_token_expiration="${{ steps.auth.outputs.access_token_expiration }}" >> $GITHUB_OUTPUT
         echo id_token="${{ steps.auth.outputs.id_token }}" >> $GITHUB_OUTPUT
     - name: 'Set up Cloud SDK'
-      if: ${{ inputs.only_auth != 'true' }}
+      #if: ${{ inputs.only_auth != 'true' }}
       uses: google-github-actions/setup-gcloud@v2
     - name: Debug gcloud auth
       shell: bash


### PR DESCRIPTION
revert optional only_auth param since it is breaking some builds and not as useful as was hoped