### PR TITLE
Use system gcloud by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# repo-name
+# gcloud-workload-identity-action
 
 Suggested use:
 

--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,10 @@ inputs:
   gcp_service_account:
     description: GCP service Account
     required: true
-  #only_auth:
-  #  description: Set to true to skip setting up gcloud SDK and just do workload ID auth
-  #  required: false
-  #  default: "false"
+  use_system_gcloud:
+    description: Set to false to install latest gcloud from web. False is required in order to install additional components
+    required: false
+    default: "true"
 outputs:
   project_id:
     description: |-
@@ -51,6 +51,9 @@ runs:
     - name: 'Set up Cloud SDK'
       #if: ${{ inputs.only_auth != 'true' }}
       uses: google-github-actions/setup-gcloud@v2
+      with:
+        # Save ~20 seconds by using the gcloud that ships with the default github actions runner (n)
+        skip_install: ${{ inputs.use_system_gcloud }}
     - name: Debug gcloud auth
       shell: bash
       run: gcloud auth list


### PR DESCRIPTION
this is faster by about 20 seconds per job (which is ~1 minute for most jobs that push a docker image). this would be a breaking change for any job that installs custom gcloud components, which at the moment does not appear to include any repos. this will also mean that the latest gcloud is not always installed if the default github actions runner does not have the latest version. there is a new parameter that allows this behavior to be overridden