### PR TITLE
chore: update github actions to latest versions

### DIFF
--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: GitHub semver release
         uses: vivantehealth/github-semver-release-action@v0
         with:

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
   steps:
     - name: 'Authenticate to Google Cloud'
       id: auth
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         workload_identity_provider: ${{ inputs.workload_identity_provider}}
         service_account: ${{ inputs.gcp_service_account }}
@@ -50,7 +50,7 @@ runs:
         echo id_token="${{ steps.auth.outputs.id_token }}" >> $GITHUB_OUTPUT
     - name: 'Set up Cloud SDK'
       #if: ${{ inputs.only_auth != 'true' }}
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@v3
       with:
         # Save ~20 seconds by using the gcloud that ships with the default github actions runner (n)
         skip_install: ${{ inputs.use_system_gcloud }}


### PR DESCRIPTION
- actions/checkout@v4 -> v5
- google-github-actions/auth@v2 -> v3
- google-github-actions/setup-gcloud@v2 -> v3
