### PR TITLE
ci: update workflow actions

### DIFF
--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -14,7 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+        with:
+          fetch-tags: true
       - name: GitHub semver release
         uses: vivantehealth/github-semver-release-action@v0
         with:


### PR DESCRIPTION
- bump actions/checkout to v6
- add fetch-tags: true to checkout in github-semver-release-action job
